### PR TITLE
Use static_cast rather than dynamic_cast

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-wayland (6.6.1-2+deepin1) unstable; urgency=medium
+
+  * Use static_cast rather than dynamic_cast.
+
+ -- Lu YaNing <luyaning@uniontech.com>  Thu, 16 May 2024 11:03:28 +0800
+
 qt6-wayland (6.6.1-2) unstable; urgency=medium
 
   * feat: Support multi-key for input context plugin

--- a/debian/patches/0002-Use-static_cast-rather-than-dynamic-cast.patch
+++ b/debian/patches/0002-Use-static_cast-rather-than-dynamic-cast.patch
@@ -1,0 +1,24 @@
+Author: Lu YaNing <luyaning@uniontech.com>
+Date:   Thur, 16 May 2024 10:45:02 +0800
+Subject: Use static_cast rather than dynamic_cast
+Upstream: https://codereview.qt-project.org/c/qt/qtwayland/+/547757
+
+
+--- qt6-wayland-6.6.1.orig/src/client/qwaylanddisplay.cpp
++++ qt6-wayland-6.6.1/src/client/qwaylanddisplay.cpp
+@@ -471,13 +471,13 @@ void QWaylandDisplay::reconnect()
+ 
+     const auto windows = QGuiApplication::allWindows();
+     for (auto window : windows) {
+-        if (auto waylandWindow = dynamic_cast<QWaylandWindow *>(window->handle()))
++        if (auto waylandWindow = static_cast<QWaylandWindow *>(window->handle()))
+             waylandWindow->closeChildPopups();
+     }
+     // Remove windows that do not need to be recreated and now closed popups
+     QList<QWaylandWindow *> recreateWindows;
+     for (auto window : std::as_const(windows)) {
+-        auto waylandWindow = dynamic_cast<QWaylandWindow*>((window)->handle());
++        auto waylandWindow = static_cast<QWaylandWindow*>((window)->handle());
+         if (waylandWindow && waylandWindow->wlSurface()) {
+             waylandWindow->reset();
+             recreateWindows.push_back(waylandWindow);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 # https://codereview.qt-project.org/c/qt/qtwayland/+/526133
 0001-Support-multi-key-for-input-context-plugin.patch
+0002-Use-static_cast-rather-than-dynamic-cast.patch


### PR DESCRIPTION
To avoid RTTI.
When I tried to implement the reconnect function in Plasma5, I found that the application would have a dynamic_cast crash problem. Referring to other usage logic and suggestions in Qt, it is recommended to avoid using dynamic_cast.

log: The client crashes and exits during reconnection.