### PR TITLE
compositor: Reset keyboard modifier state completely after screen unlock

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-wayland (6.8.0-0deepin7) UNRELEASED; urgency=medium
+
+  * compositor: Reset keyboard modifier state completely after screen unlock
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Fri, 18 Apr 2025 11:29:14 +0800
+
 qt6-wayland (6.8.0-0deepin6) unstable; urgency=medium
 
   * Fix transparent window rendering when size was not changed

--- a/debian/patches/Reset-keyboard-modifier-state-when-all-keys-are-released.patch
+++ b/debian/patches/Reset-keyboard-modifier-state-when-all-keys-are-released.patch
@@ -1,0 +1,39 @@
+Author: Tian Shilin<tianshilin@uniontech.com>
+Date:   Fri Apr 18 10:20:24 2025
+Subject:Reset keyboard modifier state when all keys are released
+Upstream: https://codereview.qt-project.org/c/qt/qtwayland/+/638357
+
+Index: qt6-wayland/src/compositor/compositor_api/qwaylandkeyboard.cpp
+===================================================================
+--- qt6-wayland.orig/src/compositor/compositor_api/qwaylandkeyboard.cpp
++++ qt6-wayland/src/compositor/compositor_api/qwaylandkeyboard.cpp
+@@ -180,11 +180,29 @@ void QWaylandKeyboardPrivate::resetKeybo
+     if (!xkbContext())
+         return;
+ 
++    // Process all pressed keys
+     while (!keys.isEmpty()) {
+         uint32_t code = fromWaylandKey(keys.first());
+         keyEvent(code, WL_KEYBOARD_KEY_STATE_RELEASED);
+         updateModifierState(code, WL_KEYBOARD_KEY_STATE_RELEASED);
+     }
++
++    // Reset XKB state directly
++    if (xkbState()) {
++        xkb_state_update_mask(xkbState(), 0, 0, 0, 0, 0, 0);
++
++        // Update internal state variables
++        modsDepressed = 0;
++        modsLatched = 0;
++        modsLocked = 0;
++        currentModifierState = Qt::NoModifier;
++
++        // Notify the client that the modifier state has been reset
++        if (focusResource) {
++            send_modifiers(focusResource->handle, compositor()->nextSerial(),
++                          modsDepressed, modsLatched, modsLocked, group);
++        }
++    }
+ }
+ #endif
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ fix-crash-when-attach-differ-shellsurface-to-the-same-shellsurfaceitem
 client-Run-waylandscanner-with-private-code.patch
 feat-export-the-symbol-of-qtkey-and-qttouch-protocol.patch
 fix_transparent_window_rendering_when_size_was_not_changed.patch
+Reset-keyboard-modifier-state-when-all-keys-are-released.patch


### PR DESCRIPTION
When returning from screen lock (e.g., after Win+L), the keyboard modifier state sometimes remains in an incorrect state (e.g., showing AltModifier or MetaModifier instead of NoModifier), which can cause keys like Delete to stop functioning properly.

This patch improves the resetKeyboardState() method to:
1. Process all pressed keys (existing behavior)
2. Explicitly reset the XKB state to zero using xkb_state_update_mask()
3. Reset the internal modifier state variables
4. Notify clients about the reset modifier state

This ensures a complete keyboard state reset when returning from locked screen, fixing issues with keyboard functionality after unlock.