### PR TITLE
fix: Notify application code of button release after leave

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-wayland (6.8.0-0deepin9) unstable; urgency=medium
+
+  * fix: Notify application code of button release after leave
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 07 May 2026 19:47:38 +0800
+
 qt6-wayland (6.8.0-0deepin8) UNRELEASED; urgency=medium
 
   * fix(Wayland): Map cursor rectangle coordinates to surface in TextInputMethodV1

--- a/debian/patches/client-Notify-application-code-of-button-release-after-leave.patch
+++ b/debian/patches/client-Notify-application-code-of-button-release-after-leave.patch
@@ -1,0 +1,28 @@
+Author: Tian Shilin<tianshilin@uniontech.com>
+Date: Thu May 07 10:20:24 2026
+Subject: Notify application code of button release after leaves
+Upstream: https://codereview.qt-project.org/c/qt/qtwayland/+/581714
+
+---
+
+Index: qt6-wayland/src/client/qwaylandinputdevice.cpp
+===================================================================
+--- qt6-wayland.orig/src/client/qwaylandinputdevice.cpp
++++ qt6-wayland/src/client/qwaylandinputdevice.cpp
+@@ -894,15 +894,7 @@ void QWaylandInputDevice::Pointer::inval
+ 
+ void QWaylandInputDevice::Pointer::releaseButtons()
+ {
+-    if (mButtons == Qt::NoButton)
+-        return;
+-
+-    mButtons = Qt::NoButton;
+-
+-    if (auto *window = focusWindow()) {
+-        ReleaseEvent e(focusWindow(), mParent->mTime, mSurfacePos, mGlobalPos, mButtons, mLastButton, mParent->modifiers());
+-        window->handleMouse(mParent, e);
+-    }
++    setFrameEvent(new ReleaseEvent(nullptr, mParent->mTime, mSurfacePos, mGlobalPos, Qt::NoButton, Qt::NoButton, mParent->modifiers()));
+ }
+ 
+ void QWaylandInputDevice::Pointer::leavePointers()

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@ feat-export-the-symbol-of-qtkey-and-qttouch-protocol.patch
 fix_transparent_window_rendering_when_size_was_not_changed.patch
 Reset-keyboard-modifier-state-when-all-keys-are-released.patch
 fix-Wayland-Map-cursor-rectangle-coordinates-to-surface-in-TextInputMethodV1.patch
+client-Notify-application-code-of-button-release-after-leave.patch


### PR DESCRIPTION
log: There is a code path to notify application code that mouse buttons are released following a drag.

Compositors we will have been sent a leave event in the meantime, making this code inert. Focus window will be null, and mButtons will be empty.

We still need to send a release event QWindowSystem event to no window, as we need to update any grabs on the device.

upsteam: https://codereview.qt-project.org/c/qt/qtwayland/+/581714