### PR TITLE
fix: add multi-seat event support for wayland input device

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-wayland (6.8.0-0deepin10) UNRELEASED; urgency=medium
+
+  * fix: add multi-seat event support for wayland input device
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Mon, 15 Jun 2026 15:27:05 +0800
+
 qt6-wayland (6.8.0-0deepin9) unstable; urgency=medium
 
   * fix: Notify application code of button release after leave

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-qt6-wayland (6.8.0-0deepin10) UNRELEASED; urgency=medium
+qt6-wayland (6.8.0-0deepin10) unstable; urgency=medium
 
   * fix: add multi-seat event support for wayland input device
 

--- a/debian/patches/qt6-wayland-add-multi-seat-event.patch
+++ b/debian/patches/qt6-wayland-add-multi-seat-event.patch
@@ -1,0 +1,180 @@
+Author: Tian Shilin<tianshilin@uniontech.com>
+Date:   Mon Jun 15 15:26:49 2026
+Subject: add multi-seat event support for wayland input device
+
+
+---
+
+Index: qt6-wayland/src/client/qwaylandinputdevice.cpp
+===================================================================
+--- qt6-wayland.orig/src/client/qwaylandinputdevice.cpp
++++ qt6-wayland/src/client/qwaylandinputdevice.cpp
+@@ -418,6 +418,16 @@ QWaylandInputDevice::QWaylandInputDevice
+     if (auto *tm = mQDisplay->tabletManager())
+         mTabletSeat.reset(new QWaylandTabletSeatV2(tm, this));
+ #endif
++
++    if (!mSeatName.isEmpty()) {
++        mKeyboardDevice.reset(new QInputDevice(
++            QString::fromLatin1("wayland-keyboard-%1").arg(mSeatName),
++            id,
++            QInputDevice::DeviceType::Keyboard,
++            mSeatName,
++            this
++        ));
++    }
+ }
+ 
+ QWaylandInputDevice::~QWaylandInputDevice()
+@@ -434,8 +444,17 @@ void QWaylandInputDevice::seat_capabilit
+ 
+     if (caps & WL_SEAT_CAPABILITY_KEYBOARD && !mKeyboard) {
+         mKeyboard.reset(createKeyboard(this));
+-    } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && mKeyboard) {
+-        mKeyboard.reset();
++        if (!mKeyboardDevice && !mSeatName.isEmpty()) {
++            mKeyboardDevice.reset(new QInputDevice(
++                QString::fromLatin1("wayland-keyboard-%1").arg(mSeatName),
++                mId,
++                QInputDevice::DeviceType::Keyboard,
++                mSeatName,
++                this
++            ));
++        }
++    } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
++        mKeyboardDevice.reset();
+     }
+ 
+     if (caps & WL_SEAT_CAPABILITY_POINTER && !mPointer) {
+@@ -479,6 +498,15 @@ void QWaylandInputDevice::seat_capabilit
+ void QWaylandInputDevice::seat_name(const QString &name)
+ {
+     mSeatName = name;
++    if (mKeyboardDevice) {
++        mKeyboardDevice.reset(new QInputDevice(
++            QString::fromLatin1("wayland-keyboard-%1").arg(name),
++            mId,
++            QInputDevice::DeviceType::Keyboard,
++            name,
++            this
++        ));
++    }
+ }
+ 
+ QWaylandInputDevice::Keyboard *QWaylandInputDevice::createKeyboard(QWaylandInputDevice *device)
+@@ -1318,7 +1346,7 @@ void QWaylandInputDevice::Keyboard::hand
+ 
+     if (inputContext) {
+         QKeyEvent event(type, key, modifiers, nativeScanCode, nativeVirtualKey,
+-                        nativeModifiers, text, autorepeat, count);
++                        nativeModifiers, text, autorepeat, count, mParent->keyboardDevice());
+         event.setTimestamp(timestamp);
+         filtered = inputContext->filterEvent(&event);
+     }
+@@ -1335,8 +1363,9 @@ void QWaylandInputDevice::Keyboard::hand
+             }
+         }
+ 
+-        QWindowSystemInterface::handleExtendedKeyEvent(window, timestamp, type, key, modifiers,
+-                nativeScanCode, nativeVirtualKey, nativeModifiers, text, autorepeat, count);
++        QWindowSystemInterface::handleExtendedKeyEvent(window, timestamp, mParent->keyboardDevice(),
++                type, key, modifiers, nativeScanCode, nativeVirtualKey, nativeModifiers, 
++                text, autorepeat, count);
+     }
+ }
+ 
+@@ -1604,6 +1633,11 @@ void QWaylandInputDevice::Touch::touch_f
+ 
+ }
+ 
++const QInputDevice *QWaylandInputDevice::keyboardDevice() const
++{
++    return mKeyboardDevice.get();
++}
++
+ }
+ 
+ QT_END_NAMESPACE
+Index: qt6-wayland/src/client/qwaylandinputdevice_p.h
+===================================================================
+--- qt6-wayland.orig/src/client/qwaylandinputdevice_p.h
++++ qt6-wayland/src/client/qwaylandinputdevice_p.h
+@@ -140,6 +140,7 @@ public:
+     QWaylandPointerGestureSwipe *pointerGestureSwipe() const;
+     QWaylandPointerGesturePinch *pointerGesturePinch() const;
+     Touch *touch() const;
++    const QInputDevice *keyboardDevice() const;
+ 
+ protected:
+     QWaylandDisplay *mQDisplay = nullptr;
+@@ -182,6 +183,7 @@ protected:
+ 
+     uint32_t mTime = 0;
+     uint32_t mSerial = 0;
++    std::unique_ptr<QInputDevice> mKeyboardDevice;
+ 
+     void seat_capabilities(uint32_t caps) override;
+     void seat_name(const QString &name) override;
+Index: qt6-wayland/src/client/qwaylandnativeinterface.cpp
+===================================================================
+--- qt6-wayland.orig/src/client/qwaylandnativeinterface.cpp
++++ qt6-wayland/src/client/qwaylandnativeinterface.cpp
+@@ -35,6 +35,8 @@ void *QWaylandNativeInterface::nativeRes
+ 
+     if (lowerCaseResource == "display" || lowerCaseResource == "wl_display" || lowerCaseResource == "nativedisplay")
+         return m_integration->display()->wl_display();
++    if (lowerCaseResource == "waylanddisplay")
++        return m_integration->display();
+     if (lowerCaseResource == "compositor") {
+         if (auto compositor = m_integration->display()->compositor())
+             return compositor->object();
+Index: qt6-wayland/src/client/qwaylandwindow.cpp
+===================================================================
+--- qt6-wayland.orig/src/client/qwaylandwindow.cpp
++++ qt6-wayland/src/client/qwaylandwindow.cpp
+@@ -1188,6 +1188,9 @@ QWaylandWindow *QWaylandWindow::guessTra
+ 
+ void QWaylandWindow::handleMouse(QWaylandInputDevice *inputDevice, const QWaylandPointerEvent &e)
+ {
++    // There's currently no way to get info about the actual hardware device in use.
++    // At least we get the correct seat.
++    const QPointingDevice *device = QPointingDevice::primaryPointingDevice(inputDevice->seatname());
+     if (e.type == QEvent::Leave) {
+         if (mWindowDecorationEnabled) {
+             if (mMouseEventsInContentArea)
+@@ -1211,10 +1214,10 @@ void QWaylandWindow::handleMouse(QWaylan
+             case QEvent::MouseButtonPress:
+             case QEvent::MouseButtonRelease:
+             case QEvent::MouseMove:
+-                QWindowSystemInterface::handleMouseEvent(window(), e.timestamp, e.local, e.global, e.buttons, e.button, e.type, e.modifiers);
++                QWindowSystemInterface::handleMouseEvent(window(), e.timestamp, device, e.local, e.global, e.buttons, e.button, e.type, e.modifiers);
+                 break;
+             case QEvent::Wheel:
+-                QWindowSystemInterface::handleWheelEvent(window(), e.timestamp, e.local, e.global,
++                QWindowSystemInterface::handleWheelEvent(window(), e.timestamp, device, e.local, e.global,
+                                                          e.pixelDelta, e.angleDelta, e.modifiers,
+                                                          e.phase, e.source, e.inverted);
+                 break;
+@@ -1378,6 +1381,9 @@ bool QWaylandWindow::handleTabletEventDe
+ 
+ void QWaylandWindow::handleMouseEventWithDecoration(QWaylandInputDevice *inputDevice, const QWaylandPointerEvent &e)
+ {
++    // There's currently no way to get info about the actual hardware device in use.
++    // At least we get the correct seat.
++    const QPointingDevice *device = QPointingDevice::primaryPointingDevice(inputDevice->seatname());
+     if (mMousePressedInContentArea == Qt::NoButton &&
+         mWindowDecoration->handleMouse(inputDevice, e.local, e.global, e.buttons, e.modifiers)) {
+         if (mMouseEventsInContentArea) {
+@@ -1411,10 +1417,10 @@ void QWaylandWindow::handleMouseEventWit
+             case QEvent::MouseButtonPress:
+             case QEvent::MouseButtonRelease:
+             case QEvent::MouseMove:
+-                QWindowSystemInterface::handleMouseEvent(window(), e.timestamp, localTranslated, globalTranslated, e.buttons, e.button, e.type, e.modifiers);
++                QWindowSystemInterface::handleMouseEvent(window(), e.timestamp, device, localTranslated, globalTranslated, e.buttons, e.button, e.type, e.modifiers);
+                 break;
+             case QEvent::Wheel: {
+-                QWindowSystemInterface::handleWheelEvent(window(), e.timestamp,
++                QWindowSystemInterface::handleWheelEvent(window(), e.timestamp, device,
+                                                          localTranslated, globalTranslated,
+                                                          e.pixelDelta, e.angleDelta, e.modifiers,
+                                                          e.phase, e.source, e.inverted);

--- a/debian/patches/qt6-wayland-add-multi-seat-event.patch
+++ b/debian/patches/qt6-wayland-add-multi-seat-event.patch
@@ -1,4 +1,4 @@
-Author: Tian Shilin<tianshilin@uniontech.com>
+Author: Tian Shilin <tianshilin@uniontech.com>
 Date:   Mon Jun 15 15:26:49 2026
 Subject: add multi-seat event support for wayland input device
 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ fix_transparent_window_rendering_when_size_was_not_changed.patch
 Reset-keyboard-modifier-state-when-all-keys-are-released.patch
 fix-Wayland-Map-cursor-rectangle-coordinates-to-surface-in-TextInputMethodV1.patch
 client-Notify-application-code-of-button-release-after-leave.patch
+qt6-wayland-add-multi-seat-event.patch


### PR DESCRIPTION
Log: In multi-seat scenarios, keyboard and mouse events lacked device identity information, making it impossible for applications to distinguish which seat generated the event. Add QInputDevice tracking to QWaylandInputDevice keyed by seat name, expose it via keyboardDevice(), and pass it through handleExtendedKeyEvent and handleMouseEvent/handleWheelEvent calls. Also expose the wayland display object via nativeResourceForIntegration("waylanddisplay").